### PR TITLE
Create RouteStructureAnalyzer.scala

### DIFF
--- a/server/src/main/scala/kpn/server/analyzer/engine/analysis/route/analyzers/RouteStructureAnalyzer.scala
+++ b/server/src/main/scala/kpn/server/analyzer/engine/analysis/route/analyzers/RouteStructureAnalyzer.scala
@@ -89,7 +89,8 @@ class RouteStructureAnalyzer(context: RouteAnalysisContext) {
 
             val oneWayRoute = context.loadedRoute.relation.tags.tags.exists { tag =>
               (tag.key == "comment" && tag.value.contains("to be used in one direction")) ||
-                (tag.key == "oneway" && tag.value == "yes")
+                (tag.key == "oneway" && tag.value == "yes") ||
+                (tag.key == "signed_direction" && tag.value == "yes")
             }
 
             val hasValidForwardPath = structure.forwardPath.isDefined && !structure.forwardPath.exists(_.broken)


### PR DESCRIPTION
Added signed_direction=yes to the possible taggings of oneway routes, as proposed in the wiki for bicycle routes though used only rarely so far.