### PR TITLE
Use preferred tile.openstreetmap.org URL

### DIFF
--- a/server/src/main/scala/kpn/core/tools/country/RingWriter.scala
+++ b/server/src/main/scala/kpn/core/tools/country/RingWriter.scala
@@ -49,7 +49,7 @@ class RingWriter {
       |    <script>
       |
       |var map = L.map('route-map');
-      |var osm = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map);
+      |var osm = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map);
       |var cycle = L.tileLayer('https://{s}.tile.opencyclemap.org/cycle/{z}/{x}/{y}.png');
       |var countryBoundaries = L.layerGroup().addTo(map);
       |


### PR DESCRIPTION
I would like to suggest using the now preferred https://tile.openstreetmap.org URL instead of the current one (`{s}`), see

https://github.com/openstreetmap/operations/issues/737