### PR TITLE
Set surface `unknown` for `highway=footway` without any other tags.

### DIFF
--- a/server/src/main/scala/kpn/server/analyzer/engine/analysis/route/segment/SurfaceAnalyzer.scala
+++ b/server/src/main/scala/kpn/server/analyzer/engine/analysis/route/segment/SurfaceAnalyzer.scala
@@ -122,7 +122,7 @@ class SurfaceAnalyzer(networkType: NetworkType, way: Way) {
             "paved"
           }
           else {
-            "unpaved"
+            "unknown"
           }
         }
         else if (way.tags.has("highway", "path")) {


### PR DESCRIPTION
Related to #142.
Currently, a `highway=footway` without any other tags is considered `unpaved`, but since the classification includes `unknown` and there is no reasonable surface assumption possible for such footways, it should be marked as `unknown`.
An example is [this way](https://www.openstreetmap.org/way/32405028) marked as [unpaved](https://knooppuntnet.nl/de/map/cycling?mode=surface&position=51.21897447,6.78618785,19&result=compact&layers=background,cycling,pois&poi-layers=hiking-biking,landmarks,restaurants,places-to-stay,tourism).