### PR TITLE
Update NetworkNameAnalyzer.scala

### DIFF
--- a/server/src/main/scala/kpn/server/analyzer/engine/analysis/network/info/analyzers/NetworkNameAnalyzer.scala
+++ b/server/src/main/scala/kpn/server/analyzer/engine/analysis/network/info/analyzers/NetworkNameAnalyzer.scala
@@ -39,11 +39,12 @@ object NetworkNameAnalyzer extends NetworkInfoAnalyzer {
     "Skateroute-netwerk ",
     " (Walcheren)",
     "Réseau Pédestre - ",
-    "Réseau pédestre de ",
     "Réseau pédestre du ",
     "Réseau pédestre des ",
     "Réseau pédestre d'",
+    "Réseau pédestre de l'",
     "Réseau pédestre de la ",
+    "Réseau pédestre de ",
     "Réseau pédestre ",
   )
 


### PR DESCRIPTION
Update ignored substrings.

Order is important because currently i.e. "Réseau pédestre de la " is not found.